### PR TITLE
Do not force action URL

### DIFF
--- a/views/templates/widget/contactform.tpl
+++ b/views/templates/widget/contactform.tpl
@@ -28,7 +28,7 @@
 {/block}
 
 <section class="login-form">
-  <form action="{$urls.pages.contact}" method="post" {if $contact.allow_file_upload}enctype="multipart/form-data"{/if}>
+  <form method="post" {if $contact.allow_file_upload}enctype="multipart/form-data"{/if}>
 
     <header>
       <h1 class="h3">{l s='Send a message' d='Modules.Contactform.Shop'}</h1>


### PR DESCRIPTION
If `action` is not specified, the form will submit to the current page.
Not forcing the action property will make easier to insert the contact form on other pages than contact page.