### PR TITLE
Fix  Exception - Transplant the contactform module to the displayAdminEndContent hook

### DIFF
--- a/contactform.php
+++ b/contactform.php
@@ -388,7 +388,9 @@ class Contactform extends Module implements WidgetInterface
     {
         $orders = [];
 
-        if (!isset($this->customer_thread['id_order']) && $this->context->customer->isLogged()) {
+        if (!isset($this->customer_thread['id_order'])
+            && isset($this->context->customer)
+            && $this->context->customer->isLogged()) {
             $customer_orders = Order::getCustomerOrders($this->context->customer->id);
 
             foreach ($customer_orders as $customer_order) {


### PR DESCRIPTION
For backoffice hooks(like `displayAdminEndContent` and `displayAdminNavBarBeforeEnd`), the variable `$this->context->customer` is null, which causes the fatal error described in [Exception - Transplant the contactform module to the displayAdminEndContent hook](https://github.com/PrestaShop/PrestaShop/issues/17707)