### PR TITLE
Add customer name to form

### DIFF
--- a/contactform.php
+++ b/contactform.php
@@ -582,12 +582,19 @@ class Contactform extends Module implements WidgetInterface
                 && ($sendConfirmationEmail || $sendNotificationEmail)
             ) {
                 $var_list = [
+                    '{firstname}' => '',
+                    '{lastname}' => '',
                     '{order_name}' => '-',
                     '{attached_file}' => '-',
                     '{message}' => Tools::nl2br(Tools::stripslashes($message)),
                     '{email}' =>  $from,
                     '{product_name}' => '',
                 ];
+
+                if (isset($customer->id)) {
+                    $var_list['{firstname}'] = $customer->firstname;
+                    $var_list['{lastname}'] = $customer->lastname;
+                }
 
                 if (isset($file_attachment['name'])) {
                     $var_list['{attached_file}'] = $file_attachment['name'];


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | When a user sends a contact form, the confirmation mail has the placeholders ({firstname} {lastname}) instead of customer's name.
| Type?         | improvement
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | NA
| How to test?  | Send a contact us request. Your name will be present in the confirmation mail, provided that you are a registered customer.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
