### PR TITLE
Changed way to get the order id into $var_list array

### DIFF
--- a/contactform.php
+++ b/contactform.php
@@ -594,8 +594,8 @@ class Contactform extends Module implements WidgetInterface
                 }
                 $id_product = (int)Tools::getValue('id_product');
 
-                if (isset($ct) && Validate::isLoadedObject($ct) && $ct->id_order) {
-                    $order = new Order((int)$ct->id_order);
+                if ($id_order) {
+                    $order = new Order((int)$id_order);
                     $var_list['{order_name}'] = $order->getUniqReference();
                     $var_list['{id_order}'] = (int)$order->id;
                 }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | The way to obtain the order id has been changed to add it to the $var_list array, since if contact does not have to save the messages in the customer service, it does not create the CustomerThread and cannot access the if that assigns the order id to the array.
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | N/A
| How to test?  | 1. Deactivate store messages in the Contact "department".<br>2. Do an order in the frontal page.<br>3. Send a message to the deparment about this order.<br>4. In the emails sent, you can see the order reference.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
