### PR TITLE
implement empty listener for registerGDPRConsent hook

### DIFF
--- a/contactform.php
+++ b/contactform.php
@@ -691,4 +691,16 @@ class Contactform extends Module implements WidgetInterface
             }
         }
     }
+
+    /**
+     * empty listener for registerGDPRConsent hook
+     */
+    public function hookRegisterGDPRConsent()
+    {
+        /* registerGDPRConsent is a special kind of hook that doesn't need a listener, see :
+           https://build.prestashop.com/howtos/module/how-to-make-your-module-compliant-with-prestashop-official-gdpr-compliance-module/
+          However since Prestashop 1.7.8, modules must implement a listener for all the hooks they register: a check is made
+          at module installation.
+        */
+    }
 }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | From now on registered hooks must have a corresponding hook listener, the `registerGDPRConsent` is a special case, we implement an empty listener.
| Type?         | improvement
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Partly fixes #19230
| How to test?  | Check that the module can still be installed without error

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
