### PR TITLE
Fixing deprecated for PHP 8.1

### DIFF
--- a/contactform.php
+++ b/contactform.php
@@ -248,7 +248,7 @@ class Contactform extends Module implements WidgetInterface
      */
     public function getWidgetVariables($hookName = null, array $configuration = [])
     {
-        $notifications = false;
+        $notifications = [];
 
         if (Tools::isSubmit('submitMessage')) {
             $this->sendMessage();


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Since PHP 8.1, Automatic conversion of `false` to `array` is deprecated. This PR aims to solve this by initing the `$notifications` variable to an empty array instead of `false`.
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes PrestaShop/Prestashop#28632
| How to test?  | Please see PrestaShop/Prestashop#28632

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
