### PR TITLE
Fix hook registration for upgraded versions

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -2,7 +2,7 @@
 <module>
     <name>contactform</name>
     <displayName><![CDATA[Contact form]]></displayName>
-    <version><![CDATA[4.4.0]]></version>
+    <version><![CDATA[4.4.1]]></version>
     <description><![CDATA[Adds a contact form to the "Contact us" page.]]></description>
     <author><![CDATA[PrestaShop]]></author>
     <tab><![CDATA[front_office_features]]></tab>

--- a/contactform.php
+++ b/contactform.php
@@ -54,7 +54,7 @@ class Contactform extends Module implements WidgetInterface
         $this->name = 'contactform';
         $this->author = 'PrestaShop';
         $this->tab = 'front_office_features';
-        $this->version = '4.4.0';
+        $this->version = '4.4.1';
         $this->bootstrap = true;
 
         parent::__construct();
@@ -76,7 +76,7 @@ class Contactform extends Module implements WidgetInterface
      */
     public function install()
     {
-        return parent::install() && $this->registerHook('registerGDPRConsent');
+        return parent::install() && $this->registerHook(['registerGDPRConsent', 'displayContactContent']);
     }
 
     /**

--- a/upgrade/Upgrade-4.4.1.php
+++ b/upgrade/Upgrade-4.4.1.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License 3.0 (AFL-3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
+ */
+if (!defined('_PS_VERSION_')) {
+    exit;
+}
+
+function upgrade_module_4_4_1($object)
+{
+    return $object->registerHook('displayContactContent');
+}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | This will force the module to hook into displayContactContent, so it works in the new version of Classic
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes PrestaShop/Prestashop#31640
| How to test?  | After the upgrade, update to this module version (it may require creating a .zip manually for the test) and see if the contactform is displayed

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
