### PR TITLE
Use PHP built-in stripslashes for PS 8.0.0+

### DIFF
--- a/contactform.php
+++ b/contactform.php
@@ -567,12 +567,13 @@ class Contactform extends Module implements WidgetInterface
             && empty($mailAlreadySend)
             && ($sendConfirmationEmail || $sendNotificationEmail)
         ) {
+            $message = version_compare(_PS_VERSION_, '8.0.0', '>=') ? stripslashes($message) : Tools::stripslashes($message);
             $var_list = [
                 '{firstname}' => '',
                 '{lastname}' => '',
                 '{order_name}' => '-',
                 '{attached_file}' => '-',
-                '{message}' => Tools::nl2br(Tools::htmlentitiesUTF8(Tools::stripslashes($message))),
+                '{message}' => Tools::nl2br(Tools::htmlentitiesUTF8($message)),
                 '{email}' => $from,
                 '{product_name}' => '',
             ];


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | [`Tools::stripslashes()` is deprecated since version 8.0.0. Use PHP's stripslashes instead.](https://github.com/PrestaShop/PrestaShop/blob/8.1.x/classes/Tools.php#L1646-L1649)
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes PrestaShop/Prestashop#34770.
| How to test?  | Apply this PR change, then follow the related issue's _Steps to reproduce_ to see the error gone.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
