### PR TITLE
ContactForm: Hide subject dropdown when only one contact is available

### DIFF
--- a/views/templates/widget/contactform.tpl
+++ b/views/templates/widget/contactform.tpl
@@ -47,15 +47,19 @@
 
     {if !$notifications || $notifications.nw_error}
       <section class="form-fields">
-
-        <label>
-          <span>{l s='Subject Heading' d='Modules.Contactform.Shop'}</span>
-          <select name="id_contact">
-            {foreach from=$contact.contacts item=contact_elt}
-              <option value="{$contact_elt.id_contact|escape:'htmlall':'UTF-8'}">{$contact_elt.name}</option>
-            {/foreach}
-          </select>
-        </label>
+        {if $contact.contacts|count === 1}
+          {assign var=firstContact value=current($contact.contacts)}
+          <input type="hidden" name="id_contact" value="{$firstContact.id_contact|escape:'htmlall':'UTF-8'}"/>
+        {else}
+          <label>
+            <span>{l s='Subject Heading' d='Modules.Contactform.Shop'}</span>
+            <select name="id_contact">
+              {foreach from=$contact.contacts item=contact_elt}
+                <option value="{$contact_elt.id_contact|escape:'htmlall':'UTF-8'}">{$contact_elt.name}</option>
+              {/foreach}
+            </select>
+          </label>
+        {/if}
 
         <label>
           <span>{l s='Email address' d='Modules.Contactform.Shop'}</span>

--- a/views/templates/widget/contactform.tpl
+++ b/views/templates/widget/contactform.tpl
@@ -55,7 +55,7 @@
             <span>{l s='Subject Heading' d='Modules.Contactform.Shop'}</span>
             <select name="id_contact">
               {foreach from=$contact.contacts item=contact_elt}
-                <option value="{$contact_elt.id_contact|escape:'htmlall':'UTF-8'}">{$contact_elt.name}</option>
+                <option value="{$contact_elt.id_contact|escape:'htmlall':'UTF-8'}">{$contact_elt.name|escape:'htmlall':'UTF-8'}</option>
               {/foreach}
             </select>
           </label>


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | When only one contact is available in the Contact Form module, the subject dropdown is no longer displayed.<br/>Instead of rendering a `<select>` with a single option, the module now automatically sets the `id_contact` value using a hidden input.<br/>This improves the user experience by removing an unnecessary selection while preserving the expected form behavior.
| Type?         | improvement 
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | - In the admin panel, go to **Shop Parameters > Contact**<br/> - Delete the contacts, leaving only one<br/> - In the front office, go to the **Contact** page<br/> - The `Subject Heading` label and its related select dropdown should not be displayed<br/> <br/> **NOTE**: <br/> If you are using the classic theme, delete (or rename) the file <br/>`themes/classic/modules/contactform/views/templates/widget/contactform.tpl`.<br/>If you are using the `hummingbird` theme, do the same.<br>This is essential to see the modification.
| Related PRs       | https://github.com/PrestaShop/hummingbird/pull/932<br/>https://github.com/PrestaShop/classic-theme/pull/201

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
---
### Before
<img width="825" height="298" alt="Before" src="https://github.com/user-attachments/assets/000f3d80-3df7-408b-87ca-8dbc5578db31" />

### After
<img width="825" height="298" alt="After" src="https://github.com/user-attachments/assets/626eb42c-3ea7-491f-a617-7ee2fb2e8298" />


### Note
If this PR is approved, I will update the `modules/contactform/views/templates/widget/contactform.tpl` file in both the classic and hummingbird themes accordingly.